### PR TITLE
Update install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,11 @@ Full documentation is available at [aquarel.readthedocs.io](https://aquarel.read
 
 ## Installation
 
-Install via pip: `pip install aquarel`
+Install via pip:
+
+```sh
+python -m pip install aquarel
+```
 
 ## Usage
 


### PR DESCRIPTION
Cover installation command to indent block so we can copy and paste the copy in Markdown.

Use the `python -m pip` installation method, see
https://snarky.ca/why-you-should-use-python-m-pip/