### PR TITLE
improve load_theme error message

### DIFF
--- a/aquarel/utils.py
+++ b/aquarel/utils.py
@@ -15,7 +15,7 @@ def load_theme(theme_name: str):
     if theme_name in themes.keys():
         return Theme.from_file(themes[theme_name])
     else:
-        raise ValueError(f"No theme named '{theme_name}' found.")
+        raise ValueError(f"No theme named '{theme_name}' found. Available options are: {list(_get_themes().keys())}")
 
 
 def list_themes():


### PR DESCRIPTION
It's a small issue but it bothered me when I first used this tool.
```
ValueError: No theme named 'minimal' found.
```
This message does not include the options users can use. I think it is better for newcomers to be able to see all the possible options after seeing an error. So I changed this message a little bit:
```
ValueError: No theme named 'minimal' found. Available options are: ['boxy_light', 'boxy_dark', 'umbra_dark', 'minimal_dark', 'minimal_light', 'arctic_dark', 'arctic_light', 'scientific', 'umbra_light']
```
Also, the options are not hard coded. The error message will adjust itself as the options change over time.