### PR TITLE
:bug: fix incompatible of `MatplotlibDeprecationWarning`

### DIFF
--- a/aquarel/theme.py
+++ b/aquarel/theme.py
@@ -234,7 +234,7 @@ class Theme:
 
     def __exit__(self, exc_type, exc_val, exc_tb):
         with warnings.catch_warnings():
-            warnings.simplefilter("ignore", mpl.cbook.MatplotlibDeprecationWarning)
+            warnings.simplefilter("ignore", mpl.MatplotlibDeprecationWarning)
             mpl.rcParams.update(self.rcparams_orig)
         self.apply_transforms()
 


### PR DESCRIPTION
After matplotlib v2.7.0 updated, the `matplotlib.cbook.MatplotlibDeprecationWarning` was deprecated, see https://matplotlib.org/stable/api/prev_api_changes/api_changes_3.7.0.html#deprecation-aliases-in-cbook

> In order to avoid downstream breakage, these aliases will now warn, and their removal has been pushed from 3.6 to 3.8 to give time to notice said warnings. As replacement, please use [matplotlib.MatplotlibDeprecationWarning](https://matplotlib.org/stable/api/matplotlib_configuration_api.html#matplotlib.MatplotlibDeprecationWarning).

This pull request, simply replaced `mpl.cbook.MatplotlibDeprecationWarning` with new came `mpl.MatplotlibDeprecationWarning` to prevent error.