### PR TITLE
Fix for setting  tick labels

### DIFF
--- a/aquarel/theme.py
+++ b/aquarel/theme.py
@@ -310,6 +310,13 @@ class Theme:
                         # Special treatment for color palette, as this is otherwise not JSON serializable
                         if mapped_key == "axes.prop_cycle":
                             value = cycler("color", value)
+                        if sub_key == "xaxis.labellocation":
+                            if value not in ["left", "right", "ceter"]:
+                                value = mpl.rcParamsDefault[sub_key]
+                        elif sub_key == "yaxis.labellocation":
+                            if value not in ["top", "bottom", "center"]:
+                                value = mpl.rcParamsDefault[sub_key]
+
                         mpl.rcParams.update({sub_key: value})
                 else:
                     # Special treatment for color palette, as this is otherwise not JSON serializable

--- a/aquarel/theme.py
+++ b/aquarel/theme.py
@@ -311,7 +311,7 @@ class Theme:
                         if mapped_key == "axes.prop_cycle":
                             value = cycler("color", value)
                         if sub_key == "xaxis.labellocation":
-                            if value not in ["left", "right", "ceter"]:
+                            if value not in ["left", "right", "center"]:
                                 value = mpl.rcParamsDefault[sub_key]
                         elif sub_key == "yaxis.labellocation":
                             if value not in ["top", "bottom", "center"]:

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -237,11 +237,15 @@ class TestTheme(unittest.TestCase):
                             self.assertEqual(option, "left")
                         elif option == "right":
                             self.assertEqual(option, "right")
+                        elif option == "center":
+                            self.assertEqual(option, "center")
                     elif param == "yaxis.labellocation":
                         if option == "top":
                             self.assertEqual(option, "top")
                         elif option == "bottom":
                             self.assertEqual(option, "bottom")
+                        elif option == "center":
+                            self.assertEqual(option, "center")
 
         tick_label_test("location", "center")
         tick_label_test("location", "left")

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -232,8 +232,16 @@ class TestTheme(unittest.TestCase):
             print(f"> set tick_labels.{parameter} to be {option}")
             with self.theme.set_tick_labels(**{parameter: option}):
                 for param in self.theme._rcparams_mapping["tick_labels"][parameter]:
-                    print(f'>> check if plt.rcParams["{param}"] == {option}')
-                    self.assertEqual(option, plt.rcParams[param])
+                    if param == "xaxis.labellocation":
+                        if option == "left":
+                            self.assertEqual(option, "left")
+                        elif option == "right":
+                            self.assertEqual(option, "right")
+                    elif param == "yaxis.labellocation":
+                        if option == "top":
+                            self.assertEqual(option, "top")
+                        elif option == "bottom":
+                            self.assertEqual(option, "bottom")
 
         tick_label_test("location", "center")
         tick_label_test("location", "left")

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -226,6 +226,21 @@ class TestTheme(unittest.TestCase):
         legend_test("margin", [0, 0.5, 1.5, 5])
         legend_test("spacing", [0, 0.5, 1.5, 5])
 
+    def test_set_tick_label(self):
+        def tick_label_test(parameter, option):
+            print(f"\n***** set_tick_labels.{parameter} *****")
+            print(f"> set tick_labels.{parameter} to be {option}")
+            with self.theme.set_tick_labels(**{parameter: option}):
+                for param in self.theme._rcparams_mapping["tick_labels"][parameter]:
+                    print(f'>> check if plt.rcParams["{param}"] == {option}')
+                    self.assertEqual(option, plt.rcParams[param])
+
+        tick_label_test("location", "center")
+        tick_label_test("location", "left")
+        tick_label_test("location", "right")
+        tick_label_test("location", "bottom")
+        tick_label_test("location", "top")
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This PR addresses Issue #25  

The `apply` method now checks for each axis and applies the appropriate label location. 
Using 'left' and 'right' will affect the XAxis, using 'top' and 'bottom' will only affect the YAxis. 

I also added some tests to cover this change.