### PR TITLE
Fix UnicodeDecodeError when apply ambivalent theme in Windows

### DIFF
--- a/aquarel/theme.py
+++ b/aquarel/theme.py
@@ -753,7 +753,7 @@ class Theme:
         :param filename: file to load theme dictionary from
         :return: cls
         """
-        with open(filename, "r") as f:
+        with open(filename, "r", encoding='utf8') as f:
             data = json.load(f)
         return cls.from_dict(data)
 


### PR DESCRIPTION
Fix error in Windows:

```py
UnicodeDecodeError                        Traceback (most recent call last)
Cell In[2], line 1
----> 1 theme = aquarel.load_theme('ambivalent')
      2 theme.apply()

File [c:\Users\Jon\AppData\Local\Programs\Python\Python312\Lib\site-packages\aquarel\utils.py:24](file:///C:/Users/Jon/AppData/Local/Programs/Python/Python312/Lib/site-packages/aquarel/utils.py:24), in load_theme(theme_name)
     22 themes = _get_themes()
     23 if theme_name in themes.keys():
---> 24     return Theme.from_file(themes[theme_name])
     25 else:
     26     raise ValueError(f"No theme named '{theme_name}' found. Available options are: {list(_get_themes().keys())}")

File [c:\Users\Jon\AppData\Local\Programs\Python\Python312\Lib\site-packages\aquarel\theme.py:757](file:///C:/Users/Jon/AppData/Local/Programs/Python/Python312/Lib/site-packages/aquarel/theme.py:757), in Theme.from_file(cls, filename)
    750 """
    751 Initialize a theme from a theme file
    752 
    753 :param filename: file to load theme dictionary from
    754 :return: cls
    755 """
    756 with open(filename, "r") as f:
--> 757     data = json.load(f)
    758 return cls.from_dict(data)

File [c:\Users\Jon\AppData\Local\Programs\Python\Python312\Lib\json\__init__.py:293](file:///C:/Users/Jon/AppData/Local/Programs/Python/Python312/Lib/json/__init__.py:293), in load(fp, cls, object_hook, parse_float, parse_int, parse_constant, object_pairs_hook, **kw)
...
    294         cls=cls, object_hook=object_hook,
    295         parse_float=parse_float, parse_int=parse_int,
    296         parse_constant=parse_constant, object_pairs_hook=object_pairs_hook, **kw)

UnicodeDecodeError: 'gbk' codec can't decode byte 0x8d in position 81: illegal multibyte sequence
Output is truncated. View as a [scrollable element](command:cellOutput.enableScrolling?ba3874c2-1c8d-4b44-9c7c-262c99cbbafb) or open in a [text editor](command:workbench.action.openLargeOutput?ba3874c2-1c8d-4b44-9c7c-262c99cbbafb). Adjust cell output [settings](command:workbench.action.openSettings?%5B%22%40tag%3AnotebookOutputLayout%22%5D)...
```